### PR TITLE
Bug: server crashes when player disconnects mid-game

### DIFF
--- a/Board.py
+++ b/Board.py
@@ -3,14 +3,15 @@ import auxillary as aux
 import numpy as np
 
 NUM_COLS, NUM_ROWS = 7, 6
-FILL_VALUE = -1
+# NUM_COLS, NUM_ROWS = 3, 3 # change to test draw state (really hard not to accidentally win)
 WINNING_NUMBER = 4
 CIRCLE = '\u25CF'
 
 class Board:
+    FILL_VALUE = -1
 
     def __init__(self, players, in_terminal=True):
-        self.board_arr = np.full((NUM_ROWS, NUM_COLS), FILL_VALUE, dtype=int)
+        self.board_arr = np.full((NUM_ROWS, NUM_COLS), self.FILL_VALUE, dtype=int)
         self.players = players
         self.winner = -1
         self.in_terminal = in_terminal 
@@ -20,7 +21,7 @@ class Board:
         playr = self.players[playr_num]
         if selected_column < len(self.board_arr[0]):
             for row in self.board_arr:
-                if row[selected_column] == FILL_VALUE:
+                if row[selected_column] == self.FILL_VALUE:
                     row[selected_column] = playr.id
                     placed = True
                     break
@@ -39,12 +40,13 @@ class Board:
         # print(f'vertical win = {vertical}')
         # print(f'positive win = {positive}')
         # print(f'negative win = {negative}')
-        return horozontal or vertical or positive or negative
+        board_is_full = not np.any(self.board_arr == self.FILL_VALUE)
+        return horozontal or vertical or positive or negative or board_is_full
     
     def check_straight(self, b):
         for row in b:
             for i in range(len(row) - WINNING_NUMBER + 1):
-                if row[i] != FILL_VALUE and np.all(row[i:i+WINNING_NUMBER] == row[i]):
+                if row[i] != self.FILL_VALUE and np.all(row[i:i+WINNING_NUMBER] == row[i]):
                     self.winner = row[i]
                     return True
         return False
@@ -52,7 +54,7 @@ class Board:
     def check_diagonal(self, b):
         for r in range(len(b) + 1 - WINNING_NUMBER):
             for c in range(len(b[0]) + 1 - WINNING_NUMBER):
-                if b[r][c] != FILL_VALUE and all(b[r][c] == b[r+k][c+k] for k in range(WINNING_NUMBER)):
+                if b[r][c] != self.FILL_VALUE and all(b[r][c] == b[r+k][c+k] for k in range(WINNING_NUMBER)):
                     self.winner = b[r][c]
                     return True
         return False

--- a/Player.py
+++ b/Player.py
@@ -16,6 +16,7 @@ class Player:
 
     @staticmethod
     def get_color(playr):
+        # TODO decouple from the player id, maybe move this function into the board class and determine it by position in list?
         return ('red', aux.RED) if playr.id % 2 == 1 else ('blue', aux.BLUE)
     
     @staticmethod

--- a/client.py
+++ b/client.py
@@ -57,17 +57,20 @@ def main():
                     continue
             
             if game_over:
-                # auxillary.color_text(players[MY_ID], players[MY_ID].name)
                 # if I am not the winner, reprint the board with the winning move
-                winning_player = Player.get_player_by_id(players, message['winner'])
                 if message['last_move'] == -2:
                     print(f"{auxillary.color_text(other_player, other_player.name)} has forfeited.")
-                if winning_player.id != MY_ID:
+                if message['winner'] != MY_ID:
                     col = message['last_move']
                     board.place_tile(col, (MY_ID + 1)%2)
                     auxillary.clear_terminal()
                     print(board)
-                print(f"The winner is {auxillary.color_text(winning_player, winning_player.name)}!")
+                # TODO if the winner is -1, then the game was a draw
+                if message['winner'] == -1:
+                    print("There are no more valid moves; the game is a draw")
+                else:
+                    winning_player = Player.get_player_by_id(players, message['winner'])
+                    print(f"The winner is {auxillary.color_text(winning_player, winning_player.name)}!")
             else: # pretty much only caused by unexpected message from server
                 print(f"The game was terminated early.")
     

--- a/server.py
+++ b/server.py
@@ -129,7 +129,10 @@ def make_players_move(message, key):
 def game_over(last_move):
     board = GAME_CONTEXT['board']
     protocols.print_and_log('game over')
-    protocols.print_and_log(f'WINNER IS {Player.get_player_by_id(board.players, board.winner).name}, player id: {Player.get_player_by_id(board.players, board.winner).id}')
+    if board.winner == Board.FILL_VALUE:
+        protocols.print_and_log("The game is a draw")
+    else:
+        protocols.print_and_log(f'WINNER IS {Player.get_player_by_id(board.players, board.winner).name}, player id: {Player.get_player_by_id(board.players, board.winner).id}')
     message = protocols.game_over(board.winner, last_move)
     for key in GAME_CONTEXT['connections']:
         protocols.send_bytes(protocols.make_json_bytes(message), key.fileobj, key.data.pub_key, True)

--- a/server.py
+++ b/server.py
@@ -115,8 +115,9 @@ def make_players_move(message, key):
     with open(protocols.SERVER_LOG_PATH, 'a') as file:
         file.write(board.draw_board_for_log()) #print in log with player id
 
-    protocols.print_and_log('Checking for game over')
-    if board.game_over():
+    over = board.game_over()
+    protocols.print_and_log(f'Checking for game over: {over}')
+    if over:
         game_over(last_move)
     GAME_CONTEXT['cur_player'] = (GAME_CONTEXT['cur_player'] + 1) % 2
 


### PR DESCRIPTION
Primarily, this handles the case where the player disconnects after the game has started. Thought I'd handled this but turns out that handling was just leaving a TODO. It is TODOne now. 

The server will detect when a player disconnects mid-game and will not only remove the connection from the selector, but will also manually set the winner of the game to the remaining player and send the gameover message. It will also ignore the next message received from the remaining client because, generally, the remaining client is waiting for input when the other one disconnects. On the client side, the client will recognize that the game was forfeited and will print a relevant message. The server will return to a waiting state and 2 more players can join and play.

There's may still be a bug with the text coloring when a player disconnects before the game haas started but I can't replicate it right now. 

Additionally:
- Handling the case where the client receives an unexpected message from the server. It will just ignore it and keep playing. Not tested cause the server obviously always does exactly what it's supposed to at all times.
- Some helpful printing when the port is assigned: either using the default, user provided, or a any available port will be printed.
- Moved the reuse address setting to BEFORE binding the socket to the port. No more waiting for reuse timeout!
- Game can result in a daw

TODO
- probably more testing
- decouple the color assignment from the player id, TODO added in the Player class. This would probably be best if the color was decided based on the relative position in the player list, and therefore should probably be set by the Board class. Cascading changes is the only thing preventing the update.
- some command line arguments polishing; when to print what (the port probably doesn't print if the user doesn't provide it, for example)
